### PR TITLE
Add posibility to build the project using `stack`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Building and running
+
+## On Haskell Platform / with `cabal`
+
 Building:
 ```shell
 cabal configure
@@ -10,6 +14,18 @@ cabal configure
 cabal install --only-dependencies
 cabal run
 ```
-Screenshots:
+
+## With `stack`
+
+Building:
+```shell
+stack build
+```
+Running:
+```shell
+stack exec htetris
+```
+
+# Screenshots
 ![](https://cloud.githubusercontent.com/assets/2439255/12403317/7e641ca0-be33-11e5-8d98-8b2afffe3720.png)
 ![](https://cloud.githubusercontent.com/assets/2439255/12403413/f6a1c0fa-be33-11e5-8770-41fb4a468b41.png)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2017-10-13
+
+packages:
+  - .
+
+extra-deps:
+  - ncurses-0.2.16


### PR DESCRIPTION
I found this package and wanted to test it (and then tackle the high-score issue this weekend or the next). I use [`stack`](https://docs.haskellstack.org/en/stable/README/) so this first PR is to allow building the project with `stack`.

It doesn't change building&running with `cabal` at all.

I also updated the `README.md` file to make sure both ways of running are there.

PS: If you want, you can submit the package to [hackage](https://hackage.haskell.org/) and [stackage](https://www.stackage.org/)