### PR TITLE
Add modules to Cabal's `other-modules` field.

### DIFF
--- a/htetris.cabal
+++ b/htetris.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 
 executable htetris
   main-is:             Main.hs
-  -- other-modules:
+  other-modules:       Tetris, TetrisCurses
   -- other-extensions:
   build-depends:       base, ncurses, random
   hs-source-dirs:      src

--- a/htetris.cabal
+++ b/htetris.cabal
@@ -1,21 +1,16 @@
 name:                htetris
 version:             0.1.0.0
--- synopsis:
--- description:
 license:             MIT
 license-file:        LICENSE
 author:              Haukur Rosinkranz & Christophe Vilain
 maintainer:          hauxir@gmail.com
--- copyright:
 category:            Game
 build-type:          Simple
--- extra-source-files:
 cabal-version:       >=1.10
 
 executable htetris
   main-is:             Main.hs
   other-modules:       Tetris, TetrisCurses
-  -- other-extensions:
   build-depends:       base, ncurses, random
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This is needed because otherwise you get the following warning on compile:

```haskell
Warning: The following modules should be added to exposed-modules or other-modules in /private/tmp/mm/haskell-tetris/htetris.cabal:
    - In htetris component:
        Tetris
        TetrisCurses

Missing modules in the cabal file are likely to cause undefined reference errors from the linker, along with other problems.
```

Also, removed the other commented lines in the cabal file.