### PR TITLE
Upgrade to latest Stackage LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2017-10-13
+resolver: lts-14.7
 
 packages:
   - .


### PR DESCRIPTION
Stackage nightly is too old and doesn't promise to be always available. An LTS is better

I'll be opening a few PRs against the repo as I was just showing this repo to a small kid to introduce him to programming and both of us got a few suggestions. Hope they are ok :)